### PR TITLE
fix(#5): Separate gpg keygrip from keyID

### DIFF
--- a/home/options.nix
+++ b/home/options.nix
@@ -20,19 +20,34 @@ let
       type = types.str;
       example = "John Doe";
     };
-    # FIXME: The keygrip is only useful for pam-gnupg, git needs another way to
-    #        identify the key.
-    gpgKey = lib.mkOption {
-      description = "The keygrip of your GPG key.";
+    signingKey = lib.mkOption {
+      description = "The signing key programs should use (i.e. git).";
       type = types.nullOr types.str;
       default = null;
-      example = "6F4ABB77A88E922406BCE6627AFEEE2363914B76";
+      example = "F016B9E770737A0B";
+    };
+    encryptionKey = lib.mkOption {
+      description = "The encryption key programs should use (i.e. pass).";
+      type = types.nullOr types.str;
+      default = null;
+      example = "F016B9E770737A0B";
     };
   };
 
   user.options = {
     enable = lib.mkEnableOption "Jalil's default user configuration";
-    unlockGpgKeyOnLogin = lib.mkEnableOption "unlocking the gpg key on login";
+    gpg = lib.mkOption {
+      description = "GnuPG Configuration.";
+      default = { };
+      type = types.submodule {
+        options.unlockKeys = lib.mkOption {
+          description = "Keygrips of keys to unlock through `pam-gnupg` when logging in.";
+          default = [ ];
+          example = [ "6F4ABB77A88E922406BCE6627AFEEE2363914B76" ];
+          type = types.listOf types.str;
+        };
+      };
+    };
     defaultIdentity = lib.mkOption {
       description = "The default identity to use in things like git.";
       type = types.submodule identity;

--- a/home/users.nix
+++ b/home/users.nix
@@ -1,13 +1,13 @@
 { config, lib, ... }:
 let
   inherit (config) jhome;
-  inherit (cfg.defaultIdentity) gpgKey;
+  inherit (cfg.defaultIdentity) signingKey;
 
   cfg = jhome.user;
   hasConfig = jhome.enable && cfg != null;
-  hasKey = gpgKey != null;
+  hasKey = signingKey != null;
   gpgHome = config.programs.gpg.homedir;
-  unlockKey = hasConfig && cfg.unlockGpgKeyOnLogin && hasKey;
+  unlockKey = hasConfig && cfg.gpg.unlockKeys != [ ];
 in
 {
   config = lib.mkMerge [
@@ -16,15 +16,14 @@ in
       programs.git.userEmail = cfg.defaultIdentity.email;
       programs.git.signing = lib.mkIf hasKey {
         signByDefault = true;
-        key = gpgKey;
+        key = signingKey;
       };
     })
     (lib.mkIf unlockKey {
       xdg.configFile.pam-gnupg.text = ''
         ${gpgHome}
 
-        ${gpgKey}
-      '';
+      '' + (lib.strings.concatLines cfg.gpg.unlockKeys);
     })
   ];
 }


### PR DESCRIPTION
`pam-gnupg` wants the keygrip, `git` wants the keyID