### PR TITLE
Fix spotifyd build issue

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -600,11 +600,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710272261,
-        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update nixpkgs to obtain fix for spotifyd build error.

Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0ad13a6833440b8e238947e47bea7f11071dc2b2' (2024-03-12)
  → 'github:NixOS/nixpkgs/b06025f1533a1e07b6db3e75151caa155d1c7eb3' (2024-03-19)
