### PR TITLE
feat(devShell): Add QEMU_OPTS_WL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 This is only intended for my use, but you can see how I overengineer stuff by
 looking at it :p (maybe you can also learn some stuff on the way).
 
-This README only has a small amount of information, if you want to see the full
-documentation then go to <https://jalil-salame.github.io/configuration.nix>. I
-also overengineerd this c: (if you want to copy this for your own project, then
-take a look at [the docs folder](./docs/default.nix).
+> [!Note]
+> This README only has a small amount of information, if you want to see the
+> full documentation then go to
+> <https://jalil-salame.github.io/configuration.nix>. I also overenginerd this
+> c: (if you want to copy the docs for your own project, then take a look at
+> [the docs folder](./docs/default.nix) and the
+> [workflow](./.github/workflows/check.yml)(`build-documentation` and
+> `deploy`)).
 
 ## Try out in a VM
 
@@ -17,10 +21,15 @@ $ nix run nixpkgs#nixos-rebuild -- build-vm --flake .#vm
 building the system configuration...
 
 Done.  The virtual machine can be started by running /nix/store/$hash-nixos-vm/bin/run-nixos-vm
-$ /nix/store/$hash-nixos-vm/bin/run-nixos-vm -vga virtio
+$ /nix/store/$hash-nixos-vm/bin/run-nixos-vm $QEMU_OPTS_WL
 ```
 
 The default user is `jdoe` and the default password is `example`.
 
 > [!Note]
-> The `-vga virtio` flag is important, sway won't run if it is missing.
+> `$QEMU_OPTS_WL` is a set of options that will enable Wayland passthrough (and
+> GPU acceleration) and give the VM 2vCPU cores and 2GiB of RAM. This will
+> significantly improve your experience when running the VM so it is
+> recommended, but if Wayland is not available or you don't have enough
+> memory/CPU cores, then you can use `-virtio vga` and/or reduce the allocated
+> resources.

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
         default = pkgs.mkShell {
           inherit (self.checks.${system}.pre-commit-check) shellHook;
           buildInputs = with pkgs; [ just self.packages.${system}.nvim ];
+          QEMU_OPTS_WL = "-smp 4 -device virtio-gpu-rutabaga,gfxstream-vulkan=on,cross-domain=on,hostmem=2G,wsi=headless";
         };
       });
     };


### PR DESCRIPTION
This var has some nice defaults if you are running a Wayland host and can spare 4vCPU cores and 2GiB of RAM.

Also improve README's documentation.
