### PR TITLE
Fix warnings due to updated dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -717,11 +717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710630940,
-        "narHash": "sha256-PXhPmvjnqEkPvR3WdXZOHpdZyiRLIfwaRSJDdOOL4Qk=",
+        "lastModified": 1711715219,
+        "narHash": "sha256-0MUG1eVHGI+BMUngFmD0egJC6M5Vsu6p2RvU4uDe+EE=",
         "owner": "jalil-salame",
         "repo": "stylix",
-        "rev": "457864578070115faba827f7c969904362005d0f",
+        "rev": "6205617a5973047b7631682938819defe0125144",
         "type": "github"
       },
       "original": {

--- a/home/default.nix
+++ b/home/default.nix
@@ -55,7 +55,7 @@ in
       programs.zoxide.enable = true;
       # Shell
       programs.zsh.enable = true;
-      programs.zsh.enableAutosuggestions = true;
+      programs.zsh.autosuggestion.enable = true;
       programs.zsh.enableCompletion = true;
       programs.zsh.autocd = true;
       programs.zsh.dotDir = ".config/zsh";


### PR DESCRIPTION
- **fix(home-manager): Zsh renamed attribute**
- **flake.lock: Update** (fix stylix warnings)
