### PR TITLE
[fix] neovim: set package explicitly

### DIFF
--- a/nvim/nixvim.nix
+++ b/nvim/nixvim.nix
@@ -17,7 +17,7 @@ in {
     (lib.optionalAttrs canSetAsDefault {defaultEditor = lib.mkDefault true;})
     (lib.optionalAttrs notStandalone {enable = lib.mkDefault true;})
     (lib.mkIf cfg.enable {
-      # package = pkgs.neovim-nightly;
+      package = pkgs.neovim;
       globals.mapleader = " ";
       # Appearance
       colorschemes = {


### PR DESCRIPTION
This should fix `nixvim` using neovim-0.9.5 instead of the unstable version.