### PR TITLE
[feat] flake: prepare for 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -349,15 +349,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1717097707,
-        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
+        "lastModified": 1716736833,
+        "narHash": "sha256-rNObca6dm7Qs524O4st8VJH6pZ/Xe1gxl+Rx6mcWYo0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
+        "rev": "a631666f5ec18271e86a5cde998cba68c33d9ac6",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-24.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -438,16 +439,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1717144377,
+        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },
@@ -468,7 +469,7 @@
         ],
         "nix-darwin": [],
         "nixpkgs": [
-          "nixpkgs"
+          "unstable"
         ],
         "treefmt-nix": "treefmt-nix"
       },
@@ -499,7 +500,8 @@
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",
         "stylix": "stylix",
-        "systems": "systems"
+        "systems": "systems",
+        "unstable": "unstable"
       }
     },
     "stylix": {
@@ -521,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716800695,
-        "narHash": "sha256-5ZHVsIg5akOIWImypmQMX/fXZZf3/7tzqJICLteFGZc=",
+        "lastModified": 1717250350,
+        "narHash": "sha256-l7y55WbUrj4NVCzgo3GLmM1Z2HC2uLb8dLUt7FxfI5g=",
         "owner": "jalil-salame",
         "repo": "stylix",
-        "rev": "036128f2517b1ff7d33d04773f48ea98d680128f",
+        "rev": "03a8c7744903f29f017fabeda833834bd873f956",
         "type": "github"
       },
       "original": {
@@ -569,6 +571,21 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,8 @@
   description = "My NixOS configuration";
   # Flake inputs
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
+    unstable.url = "nixpkgs/nixos-unstable";
     # Software
     jpassmenu = {
       url = "github:jalil-salame/jpassmenu";
@@ -29,10 +30,11 @@
     };
     # Modules
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-24.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nixos-hardware.url = "github:NixOS/nixos-hardware";
+    # FIXME: pin to 24.05 when avalialble
     stylix = {
       url = "github:jalil-salame/stylix/enable-option";
       inputs = {
@@ -43,7 +45,7 @@
     nixvim = {
       url = "github:nix-community/nixvim";
       inputs = {
-        nixpkgs.follows = "nixpkgs";
+        nixpkgs.follows = "unstable";
         devshell.follows = "devshell";
         nix-darwin.follows = ""; # disable MacOS stuff
         home-manager.follows = "home-manager";
@@ -69,14 +71,13 @@
   outputs = {
     self,
     nixpkgs,
+    unstable,
     stylix,
     home-manager,
     nixos-hardware,
     jpassmenu,
     audiomenu,
     nixvim,
-    # neovim-flake,
-    # neovim-src,
     lix,
     lix-module,
     ...
@@ -158,10 +159,15 @@
       nixvim = nixvim.overlays.default;
       jpassmenu = jpassmenu.overlays.default;
       audiomenu = audiomenu.overlays.default;
-      # FIXME: remove once merged in nixpkgs
-      # neovim-nightly = final: prev: {
-      #   neovim = final.callPackage (neovim-flake + "/flake/packages/neovim.nix") {inherit neovim-src;};
-      # };
+      unstable = final: prev: {
+        inherit
+          (unstable.legacyPackages.${prev.system})
+          gitoxide
+          jujutsu
+          wezterm
+          ;
+        unstable = unstable.legacyPackages.${prev.system};
+      };
     };
 
     # Nix files formatter (run `nix fmt`)

--- a/home/default.nix
+++ b/home/default.nix
@@ -14,11 +14,7 @@ in {
   imports =
     [
       # Apply overlays
-      {
-        nixpkgs = {
-          inherit overlays;
-        };
-      }
+      {nixpkgs = {inherit overlays;};}
       nvim-config
       ./options.nix
       ./gui
@@ -26,12 +22,11 @@ in {
     ]
     ++ lib.optionals (stylix != null) [
       stylix.homeManagerModules.stylix
-      {
-        stylix.image = cfg.sway.background;
-      }
+      {stylix.image = cfg.sway.background;}
     ];
 
   config = lib.mkMerge [
+    (lib.mkIf (cfg.enable && cfg.styling.enable) {stylix.enable = true;})
     (lib.mkIf cfg.enable {
       programs = {
         # Better cat (bat)

--- a/home/gui/default.nix
+++ b/home/gui/default.nix
@@ -41,7 +41,7 @@ in {
       ++ lib.optional flatpakEnabled flatpak;
     fonts.fontconfig = {
       enable = true;
-      defaultFonts = {
+      defaultFonts = lib.mkIf config.jhome.styling.enable {
         emoji = ["Noto Color Emoji"];
         monospace = ["JetBrains Mono" "Symbols Nerd Font"];
         serif = ["Noto Serif" "Symbols Nerd Font"];
@@ -54,7 +54,7 @@ in {
       # Dynamic Menu
       fuzzel = {
         enable = true;
-        settings.main = {
+        settings.main = lib.mkIf config.jhome.styling.enable {
           icon-theme = "Papirus-Dark";
           inherit (cfg) terminal;
           layer = "overlay";
@@ -69,8 +69,8 @@ in {
       waybar = {
         enable = true;
         systemd.enable = true;
-        settings = import ./waybar-settings.nix {inherit config lib;};
-        style = ''
+        settings = lib.mkIf config.jhome.styling.enable (import ./waybar-settings.nix {inherit config lib;});
+        style = lib.optionalString config.jhome.styling.enable ''
           .modules-left #workspaces button {
             border-bottom: 3px solid @base01;
           }
@@ -82,7 +82,7 @@ in {
       # Terminal
       wezterm = {
         enable = cfg.terminal == "wezterm";
-        extraConfig = ''
+        extraConfig = lib.optionalString config.jhome.styling.enable ''
           config = {}
           config.hide_tab_bar_if_only_one_tab = true
           config.window_padding = { left = 1, right = 1, top = 1, bottom = 1 }
@@ -90,7 +90,7 @@ in {
         '';
       };
       alacritty.enable = cfg.terminal == "alacritty";
-      zellij.enable = cfg.terminal == "alacritty"; # alacritty has no terminal multiplexerr built in
+      zellij.enable = cfg.terminal == "alacritty"; # alacritty has no terminal multiplexer built-in
       # PDF reader
       zathura.enable = true;
       # Auto start sway
@@ -128,26 +128,26 @@ in {
 
     # Window Manager
     wayland.windowManager.sway = {
-      enable = true;
+      inherit (cfg.sway) enable;
       package = swayPkg; # no sway package if it comes from the OS
       config = import ./sway-config.nix {inherit config pkgs;};
     };
 
     # Set cursor style
-    stylix = {inherit cursor;};
-    home.pointerCursor = {
+    stylix = lib.mkIf config.jhome.styling.enable {inherit cursor;};
+    home.pointerCursor = lib.mkIf config.jhome.styling.enable (lib.mkDefault {
       gtk.enable = true;
       inherit (cursor) name package;
-    };
+    });
     # Set Gtk theme
-    gtk = {
+    gtk = lib.mkIf config.jhome.styling.enable {
       enable = true;
       inherit iconTheme;
       gtk3.extraConfig.gtk-application-prefer-dark-theme = 1;
       gtk4.extraConfig.gtk-application-prefer-dark-theme = 1;
     };
     # Set Qt theme
-    qt = {
+    qt = lib.mkIf config.jhome.styling.enable {
       enable = true;
       platformTheme.name = "gtk";
     };

--- a/nvim/nixvim.nix
+++ b/nvim/nixvim.nix
@@ -61,14 +61,16 @@ in {
         plugins.nvim-web-devicons
         jjdescription
       ];
-      # Formatting
+      # Formatting & linters
       extraPackages = [
+        pkgs.unstable.alejandra
+        pkgs.unstable.luajitPackages.jsregexp
+        pkgs.unstable.statix
         pkgs.unstable.stylua
         pkgs.unstable.shfmt
         pkgs.unstable.taplo
+        pkgs.unstable.typos
         pkgs.unstable.yamlfmt
-        pkgs.unstable.alejandra
-        pkgs.unstable.luajitPackages.jsregexp
       ];
       extraConfigLuaPre = ''
         -- Lua Pre Config

--- a/nvim/nixvim.nix
+++ b/nvim/nixvim.nix
@@ -17,7 +17,7 @@ in {
     (lib.optionalAttrs canSetAsDefault {defaultEditor = lib.mkDefault true;})
     (lib.optionalAttrs notStandalone {enable = lib.mkDefault true;})
     (lib.mkIf cfg.enable {
-      # package = pkgs.neovim;
+      package = pkgs.unstable.neovim-unwrapped;
       globals.mapleader = " ";
       # Appearance
       colorschemes.gruvbox = {
@@ -50,12 +50,12 @@ in {
         # Enable local configuration :h 'exrc'
         exrc = true; # safe since nvim 0.9
       };
-      plugins = import ./plugins.nix {inherit lib pkgs;};
+      plugins = import ./plugins.nix {inherit lib;};
       keymaps = import ./mappings.nix;
       inherit (import ./augroups.nix) autoGroups autoCmd;
       extraPlugins = let
-        plugins = pkgs.vimPlugins;
-        jjdescription = pkgs.callPackage ./vim-jjdescription.nix {};
+        plugins = pkgs.unstable.vimPlugins;
+        jjdescription = pkgs.unstable.callPackage ./vim-jjdescription.nix {};
       in [
         plugins.nui-nvim
         plugins.nvim-web-devicons
@@ -63,14 +63,12 @@ in {
       ];
       # Formatting
       extraPackages = [
-        pkgs.stylua
-        pkgs.shfmt
-        pkgs.taplo
-        pkgs.yamlfmt
-        pkgs.nixpkgs-fmt
-        pkgs.alejandra
-        pkgs.nixfmt-classic
-        pkgs.luajitPackages.jsregexp
+        pkgs.unstable.stylua
+        pkgs.unstable.shfmt
+        pkgs.unstable.taplo
+        pkgs.unstable.yamlfmt
+        pkgs.unstable.alejandra
+        pkgs.unstable.luajitPackages.jsregexp
       ];
       extraConfigLuaPre = ''
         -- Lua Pre Config

--- a/nvim/plugins.nix
+++ b/nvim/plugins.nix
@@ -1,7 +1,4 @@
-{
-  lib,
-  pkgs,
-}: {
+{lib}: {
   bacon = {
     enable = true;
     settings.quickfix.enabled = true;

--- a/nvim/plugins.nix
+++ b/nvim/plugins.nix
@@ -212,11 +212,11 @@
     enable = true;
     lintersByFt = {
       rust = ["typos"];
-      latex = [
-        "chktex"
-        "typos"
-      ];
+      latex = ["chktex" "typos"];
       markdown = ["typos"];
+      nix = ["statix"];
+      sh = ["dash"];
+      zsh = ["zsh"];
     };
   };
 }

--- a/system/default.nix
+++ b/system/default.nix
@@ -22,7 +22,6 @@ in {
     ./options.nix
     ./gui
     stylix.nixosModules.stylix
-    # FIXME(https://github.com/danth/stylix/issues/216): Must configure stylix
     {stylix = import ./stylix-config.nix {inherit config pkgs;};}
   ];
 


### PR DESCRIPTION
We add an `unstable` overlay (available through `pkgs.unstable`) and pin nixpkgs to the `nixos-24.05` branch.

Closes #22