### PR TITLE
[fix] nvim: give nvim access to the silicon binary

### DIFF
--- a/nvim/extraPlugins/nvim-silicon.nix
+++ b/nvim/extraPlugins/nvim-silicon.nix
@@ -1,11 +1,9 @@
 {
   vimUtils,
   fetchFromGitHub,
-  silicon,
 }:
 vimUtils.buildVimPlugin {
   name = "nvim-silicon";
-  dependencies = [silicon];
   src = fetchFromGitHub {
     owner = "michaelrommel";
     repo = "nvim-silicon";

--- a/nvim/nixvim.nix
+++ b/nvim/nixvim.nix
@@ -64,6 +64,7 @@ in {
       ];
       # Formatting & linters
       extraPackages = [
+        pkgs.unstable.silicon
         pkgs.unstable.alejandra
         pkgs.unstable.luajitPackages.jsregexp
         pkgs.unstable.statix


### PR DESCRIPTION
Marking it as a dependency of `nvim-silicon` is not enough.